### PR TITLE
Update start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -63,7 +63,7 @@ echo "*** Configure docker environment ..."
 eval $(minishift docker-env)
 
 echo "*** Set up datavirt templates ..."
-pushd ~/minishift &> /dev/null
+pushd ~/.minishift &> /dev/null
     rm -fr library
     git clone https://github.com/openshift/library.git
 


### PR DESCRIPTION
changed 'pushd ~/minishift' to 'pushd ~/.minishift'. It works, but it's putting the templates in the local dir because the 'pushd' command is silently failing because of the redirection to /dev/null. Just a nit.